### PR TITLE
Bugfix: correct gitattributes for broken images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Autodetect text files
-* text=auto
+* text=auto eol=lf
 
-# Force the following filetypes to have unix eols, so Windows does not break them
-*.* text eol=lf
+# Handle binary files as such
+*.png binary
+*.jpg binary


### PR DESCRIPTION
### Description & Changelog
Update .gitattributes to include images as binary

### Checklist
- [x] Changes were manually tested
- [ ] Unit tests were created/updated
- [ ] Documentation was created/updated
- [ ] Dependencies were updated
- [ ] CI/CD changes were made
- [ ] There are other changes not related to the ticket
