### PR TITLE
CI: Set node version to 14 for release step of CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
   "Release Library":
     working_directory: ~/ttsa-npm-lib
     docker:
-      - image: node:12.16.1
+      - image: node:14.19.0
     steps:
       - checkout
       - npm-auth


### PR DESCRIPTION
### Description & Changelog
- Set node version to 14 for release step of CI

### Checklist
- [x] Changes were manually tested
- [ ] Unit tests were created/updated
- [ ] Documentation was created/updated
- [ ] Dependencies were updated
- [x] CI/CD changes were made
- [ ] There are other changes not related to the ticket

