### PR TITLE
Build: set website dir as asset to update in versioning

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -37,7 +37,12 @@ module.exports = {
     [
       '@semantic-release/git',
       {
-        assets: ['CHANGELOG.md', 'package.json', 'package-lock.json'],
+        assets: [
+          'website/**/*',
+          'CHANGELOG.md',
+          'package.json',
+          'package-lock.json'
+        ],
         message:
           // eslint-disable-next-line no-template-curly-in-string
           'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'


### PR DESCRIPTION
### Description & Changelog
- set website dir as asset to update in versioning

### Checklist
- [x] Changes were manually tested
- [ ] Unit tests were created/updated
- [ ] Documentation was created/updated
- [ ] Dependencies were updated
- [x] CI/CD changes were made
- [ ] There are other changes not related to the ticket
