### PR TITLE
Fix/Add missing config option, apiServerStartupTimeout

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,8 +11,12 @@ const createInitialConfigFile = require('../lib/create-initial-config-file');
 const isDockerEnv = require('./helpers/is-docker-env');
 
 const options = yargs(hideBin(process.argv))
+  .number('apiServerStartupTimeout')
   .array('excludedMethods')
   .array(['excludedStatusCodes'])
+  .parserConfiguration({
+    'camel-case-expansion': false
+  })
   .parse();
 const { init } = options;
 const isCli = true;

--- a/website/docs/docker/running-tests.md
+++ b/website/docs/docker/running-tests.md
@@ -53,6 +53,7 @@ docker run -it \
   testosa/testosa:latest \
   // highlight-start
   --apiBaseUrl='https://api.your-server.com' \
+  --apiServerStartupTimeout=5000 \
   --excludedMethods='options' 'trace' \
   --excludedStatusCodes=422 500 \
   --hooksFilePath='/app/testosa.hooks.js'
@@ -83,6 +84,7 @@ The mapping for your hooks file inside the container can be set to any path you 
 | `-v /.../testosa.config.json` | Map your Testosa config file to the _exact_ path `/app/testosa.config.json` inside the container |
 | `-v /.../hooks/file.js`       | Map your hooks file to a location within the working directory (`/app`) inside the container     |
 | `--apiBaseUrl`                | Base URL of the API server that tests will be run against                                        |
+| `--apiServerStartupTimeout`   | Maximum time (in milliseconds) Testosa waits when confirming your API server is reachable        |
 | `--excludedMethods`           | Space-delimited list of HTTP methods to skip during your Testosa test run                        |
 | `--excludedStatusCodes`       | Space-delimited list of HTTP status codes to skip during your Testosa test run                   |
 | `--hooksFilePath`             | Path to the hooks file mounted **inside the container**                                          |

--- a/website/docs/docker/testing-api-on-host.md
+++ b/website/docs/docker/testing-api-on-host.md
@@ -17,6 +17,7 @@ docker run -it \
   testosa/testosa:latest \
   // highlight-next-line
   --apiBaseUrl='http://host.docker.internal:8080' \
+  --apiServerStartupTimeout=5000 \
   --excludedMethods='options' 'trace' \
   --excludedStatusCodes=422 500 \
   --hooksFilePath='/app/testosa.hooks.js'

--- a/website/docs/introduction/configuration.md
+++ b/website/docs/introduction/configuration.md
@@ -23,6 +23,10 @@ The options below can be used in both your _testosa.config.js_ and as CLI argume
 Base URL for the API server that you are validating your OpenAPI specification against.
 - Format: URI
 
+### apiServerStartupTimeout [integer]
+At the start of each test run, this is the maximum time (in milliseconds) Testosa waits when verifying that your API server is reachable.
+- Default: `5000`
+
 ### excludedMethods [array<string\>]
 An array of HTTP methods that should be skipped when generating tests. Testosa will not attempt to test any method + path combination that includes a method specified in this array.
 - Allowed values: `DELETE`, `GET`, `OPTIONS`, `PATCH`, `POST`, `PUT`, `TRACE`


### PR DESCRIPTION
### Description & Changelog
- add missing config option, apiServerStartupTimeout

### Checklist
- [x] Changes were manually tested
- [ ] Unit tests were created/updated
- [x] Documentation was created/updated
- [ ] Dependencies were updated
- [ ] CI/CD changes were made
- [ ] There are other changes not related to the ticket
